### PR TITLE
コメントの並べ替え機能を追加

### DIFF
--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -4,13 +4,13 @@ class BugsController < ApplicationController
 
   def index
     @search_bugs_form = SearchBugsForm.new(search_params)
-    @bugs = @search_bugs_form.search.page(params[:page]) 
+    @bugs = @search_bugs_form.search.page(params[:page])
   end
 
   def show
     @radar_chart = @bug.radar_chart
     @other_bug = RadarChart.offset(rand(RadarChart.count)).first.bug
-    @comments = @bug.comments
+    @comments = @bug.comments.order(created_at: :desc)
     @comment = Comment.new
     @url = bug_comments_path(@bug)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,5 @@
 class CommentsController < ApplicationController
+  include CommentsHelper
 
   def create
     comment = current_user.comments.build(comment_params)
@@ -13,6 +14,11 @@ class CommentsController < ApplicationController
     @comment = current_user.comments.find(params[:id])
     @comment.destroy!
     redirect_to bug_path(@comment.bug), success: 'コメントを削除しました'
+  end
+
+  def sort
+    @bug = Bug.find(params[:bug_id])
+    sort_type(params[:bug][:type])
   end
 
   private

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,11 @@
+module CommentsHelper
+  def sort_type(type)
+    if type == 'like'
+      @comments = @bug.comments.sort_like
+    elsif type == 'asc'
+      @comments = @bug.comments.order(created_at: :asc)
+    else
+      @comments = @bug.comments.order(created_at: :desc)
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,6 @@ class Comment < ApplicationRecord
   has_many :likes, dependent: :destroy
 
   validates :sentence, presence: true, length: { maximum: 3_000 }
+
+  scope :sort_like, -> {includes(:likes).sort { |a,b| b.likes.count <=> a.likes.count }}
 end

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -31,6 +31,10 @@
           <div class="col-6">
             <h3 class="mb-3">コメント一覧</h3>
             <% if @comments.present? %>
+              <div class="comment_order_button">
+                <button class="order_desc">新着順</button>
+                <button class="order_like">いいね順</button>
+              </div>
               <%= render 'comments/comments', comments: @comments %>
             <% else %>
               <p>コメントがありません</p>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -32,10 +32,11 @@
             <h3 class="mb-3">コメント一覧</h3>
             <% if @comments.present? %>
               <div class="comment_order_button">
-                <button class="order_desc">新着順</button>
-                <button class="order_like">いいね順</button>
+                <%= render 'comments/comments_sort', bug: @bug %>
               </div>
-              <%= render 'comments/comments', comments: @comments %>
+              <div class="comment-page">
+                <%= render 'comments/comments', comments: @comments %>
+              </div>
             <% else %>
               <p>コメントがありません</p>
             <% end %>

--- a/app/views/comments/_comments_sort.html.erb
+++ b/app/views/comments/_comments_sort.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: bug, url: bug_comments_sort_path(bug), method: :get do |f| %>
+  <div class="row">
+    <div class="form-group col-3">
+      <%= f.select :type, [['新しい順', 'desc'], ['古い順', 'asc'], ['いいね順', 'like']], { include_blank: false }, class: 'form-select' %>
+    </div>
+    <div class="actions mb-3 col-3">
+      <%= f.submit '変更する', class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/sort.js.erb
+++ b/app/views/comments/sort.js.erb
@@ -1,0 +1,1 @@
+$('.comment-page').html("<%= j(render('comments/comments', comments: @comments)) %>")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :bugs do
     get 'search', to: 'bugs#detailed_search', on: :collection
+    get 'comments/sort', to: 'comments#sort'
     resource :radar_chart, only: %i[new create edit update]
     resources :comments, only: %i[create destroy], shallow: true do
       resources :likes, only: %i[create destroy]


### PR DESCRIPTION
## 概要

- 「新しい順」「古い順」「いいね順」にソートできる機能を追加
- デフォルトでは「新しい順」に修正
- ソートはajax化

## 確認方法

- 「新しい順」を選択して「変更する」ボタンを押すとコメントの順番が新しい順になること
- 「古い順」を選択して「変更する」ボタンを押すとコメントの順番が古い順になること
- 「いいね順」を選択して「変更する」ボタンを押すとコメントの順番がいいねが多い順になること
- 「変更する」ボタンを押した時にajax通信になっていること
