### PR TITLE
画像検索画面に画像のプレビューを表示

### DIFF
--- a/app/javascript/image_search_preview.js
+++ b/app/javascript/image_search_preview.js
@@ -1,0 +1,18 @@
+document.addEventListener("turbolinks:load", function() {
+  $(function(){
+    $("#input_image").change(function(e){
+      var file = e.target.files[0];
+      var reader = new FileReader
+      console.log(file)
+
+      reader.onload = (function(){
+        return function(e){
+          $("#image_preview").css("display", "");
+          $("#image_preview").css({"width":"300px", "height":"300px"});
+          $("#image_preview").attr("src", e.target.result);
+        };
+      })(file);
+      reader.readAsDataURL(file);
+    })
+  })
+})

--- a/app/javascript/image_search_preview.js
+++ b/app/javascript/image_search_preview.js
@@ -1,17 +1,14 @@
 document.addEventListener("turbolinks:load", function() {
   $(function(){
-    $("#input_image").change(function(e){
-      var file = e.target.files[0];
+    $("#input_image").change(function(){
+      var file = $(this).prop('files')[0];
       var reader = new FileReader
-      console.log(file)
 
       reader.onload = (function(){
-        return function(e){
-          $("#image_preview").css("display", "");
-          $("#image_preview").css({"width":"300px", "height":"300px"});
-          $("#image_preview").attr("src", e.target.result);
-        };
-      })(file);
+        $("#image_preview").css("display", "");
+        $("#image_preview").css({"width":"300px", "height":"300px"});
+        $("#image_preview").attr("src", reader.result);
+      });
       reader.readAsDataURL(file);
     })
   })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,6 +15,7 @@ require("channels")
 require("jquery")
 require("tab_menu")
 require("image_blur")
+require("image_search_preview")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/bugs/_image_search_page.html.erb
+++ b/app/views/bugs/_image_search_page.html.erb
@@ -15,8 +15,11 @@
             <div class="col-12">
               <%= form_with url: image_search_bugs_path, method: :post, local: true do |f| %>
                 <div class="form-group mb-3">
-                  <p>検索したい画像を添付してください</p>
-                  <%= f.file_field :image, class: 'form-control' %>
+                  <p style="color: red;">※ファイル形式は`png`か`jpeg`でお願いします。</p>
+                  <%= f.file_field :image, class: 'form-control', id: 'input_image', accept: 'image/png, image/jpeg' %>
+                </div>
+                <div class="mb-3">
+                  <img id="image_preview", style="display: none;" />
                 </div>
                 <div class="actions mb-3">
                   <%= f.submit '検索する', class: 'btn btn-primary' %>


### PR DESCRIPTION
close #39 
## 概要

- 画像検索画面で添付した画像をプレビューとして表示する。

[![Image from Gyazo](https://i.gyazo.com/83d87aa0b19d17a3ad1514efd226d1cc.gif)](https://gyazo.com/83d87aa0b19d17a3ad1514efd226d1cc)

## 確認方法

- 画像検索画面で添付した画像がプレビューとして表示されること。

