### PR TITLE
虫関連のニュースを一覧表示する画面を追加

### DIFF
--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -26,7 +26,7 @@ class BugsController < ApplicationController
 
   def create
     @bug = current_user.bugs.build(bug_params)
-    @bug.image.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default.png')), filename: "default.png", content_type: "image/png") unless @bug.image.attached?
+    # @bug.image.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default.png')), filename: "default.png", content_type: "image/png") unless @bug.image.attached?
     if @bug.save
       redirect_to @bug, success: '登録しました'
     else

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,0 +1,7 @@
+class NewsController < ApplicationController
+  include NewsHelper
+
+  def index
+    @news_list = get_news
+  end
+end

--- a/app/decorators/news_decorator.rb
+++ b/app/decorators/news_decorator.rb
@@ -1,0 +1,13 @@
+class NewsDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/helpers/news_helper.rb
+++ b/app/helpers/news_helper.rb
@@ -1,0 +1,34 @@
+module NewsHelper
+  def get_news
+    require 'net/https'
+    require 'uri'
+    require 'json'
+
+    accessKey = "95125e33b28c4c1eb536a40161798238"
+
+    uri  = "https://api.bing.microsoft.com/"
+    path = "/v7.0/news/search"
+    count = "20"
+
+    term = "虫"
+
+    uri = URI(uri + path + "?count=" + count + "&q=" + URI.escape(term))
+
+    request = Net::HTTP::Get.new(uri)
+    request['Ocp-Apim-Subscription-Key'] = accessKey
+
+    response = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+        http.request(request)
+    end
+
+    json_news_list = JSON.parse(response.body)
+    news_list = json_news_list["value"]
+
+    # news_list.each do |news|
+    #   puts 'name : ' + news["name"]
+    #   puts 'url : ' + news["url"]
+    #   puts 'thumbnail : ' + news["image"]["thumbnail"]["contentUrl"] if news["image"]
+    #   puts 
+    # end
+  end
+end

--- a/app/views/bugs/_bug.html.erb
+++ b/app/views/bugs/_bug.html.erb
@@ -1,9 +1,13 @@
-<div class="col-sm-12 col-md-4">
+<div class="col-sm-6 offset-sm-3 col-lg-4 offset-lg-0 mb-3" style="width: 300;">
   <div class="card">
     <h3 class="card-title"><%= bug.name %></h3>
-    <%= image_tag bug.image, size: '300x200', class: "card-mig-top blur blur_#{bug.id} blur_active" %>
-    <button class="btn-danger blur_button blur_button_<%= bug.id %>" value="<%= bug.id %>">モザイクを外してみる</button>
-    <button class="btn-primary hide_blur_button hide_blur_button_<%= bug.id %> hide_button" value="<%= bug.id %>">やっぱりモザイクをつける</button>
+    <% if bug.image.attached? %>
+      <%= image_tag bug.image, class: "card-mig-top blur blur_#{bug.id} blur_active", height: '250px' %>
+      <button class="btn-danger blur_button blur_button_<%= bug.id %>" value="<%= bug.id %>">モザイクを外してみる</button>
+      <button class="btn-primary hide_blur_button hide_blur_button_<%= bug.id %> hide_button" value="<%= bug.id %>">やっぱりモザイクをつける</button>
+    <% else %>
+      <%= image_tag 'sorry.png', class: 'card-img-top', height: '250px' %>
+    <% end %>
     <%#= render 'radar_charts/radar_chart', bug: bug %>
     <div class="card-body">
       <p class="card-text"><%= bug.feature.truncate(47) %></p>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -5,11 +5,13 @@
       <button class="btn-danger blur_button blur_button_<%= @bug.id %>" value="<%= @bug.id %>">モザイクを外してみる</button>
       <button class="btn-primary hide_blur_button hide_blur_button_<%= @bug.id %> hide_button" value="<%= @bug.id %>">やっぱりモザイクをつける</button>
       <div class="line-one col-12 mb-5" style="overflow: hidden;">
-        <% if @bug.image.attached? %>
-          <div class="bug-image-contents col-6 float-start">
+        <div class="bug-image-contents col-6 float-start">
+          <% if @bug.image.attached? %>
             <%= image_tag @bug.image, size: '300x200', class: "blur blur_#{@bug.id} blur_active" %>
-          </div>
-        <% end %>
+          <% else %>
+            <%= image_tag 'sorry.png', class: 'card-img-top', height: '250px' %>
+          <% end %>
+        </div>
         <div class="radar-chart col-6 float-start">
           <% if @bug.radar_chart %>
             <%= render 'radar_charts/radar_chart', bug: @bug, other_bug: @other_bug %>
@@ -49,5 +51,6 @@
     </div>
   </div>
   <%= link_to 'Edit', edit_bug_path(@bug) %> |
+  <%= link_to 'delete', bug_path(@bug), method: :delete, data: { confirm: '削除してもよろしいですか？' } %> |
   <%= link_to 'Back', bugs_path %> 
 </div>

--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -1,0 +1,13 @@
+<div class="col-sm-6 offset-sm-3 col-lg-4 offset-lg-1 mb-3" style="width: 300;">
+  <div class="card">
+    <% if news["image"] %>
+      <%= image_tag news["image"]["thumbnail"]["contentUrl"], class: 'card-img-top', height: '250px' %>
+    <% else %>
+      <%= image_tag 'sorry.png', class: 'card-img-top', height: '250px' %>
+    <% end %>
+    <div class="card-body">
+      <%= link_to news["name"], news["url"], class: 'card-title' %>
+      <p class="card-text"><%= news["description"].truncate(100) %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <h1>虫のニュース一覧</h1>
+  <div class="row">
+    <%= render partial: 'news', collection: @news_list, as: :news %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,6 +14,9 @@
           <%= render '/bugs/image_search_page' %>
         </li>
         <li class="nav-item">
+          <%= link_to '新着情報', news_path, class: 'nav-link' %>
+        </li>
+        <li class="nav-item">
           <%= link_to '新規作成', new_bug_path, class: 'nav-link' %>
         </li>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,12 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resources :search_images, only: %i[new create]
   resources :bugs do
-    collection do
-      post 'image_search', to: 'bugs#image_search'
-    end
+    post 'image_search', to: 'bugs#image_search', on: :collection
     get 'comments/sort', to: 'comments#sort'
     resource :radar_chart, only: %i[new create edit update]
     resources :comments, only: %i[create destroy], shallow: true do
       resources :likes, only: %i[create destroy]
     end
   end
+  get 'news', to: 'news#index'
 end


### PR DESCRIPTION
close #37 
## 概要

- ニュース記事を取得できる`bing news search api`を導入する 
- 新着情報画面を作って、虫に関するニュースのみを一覧表示する

## 確認方法

「新着情報」ボタンを押すと、虫のニュース一覧が表示されること。
