### PR TITLE
bulletのインストールとactivestorageのn+1問題の解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development do
 
   gem 'better_errors'
   gem 'binding_of_caller'
+
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.35.3)
       addressable
@@ -337,6 +340,7 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (2.0.0)
+    uniform_notifier (1.14.2)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -368,6 +372,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   capybara
   dotenv-rails

--- a/app/forms/search_bugs_form.rb
+++ b/app/forms/search_bugs_form.rb
@@ -15,7 +15,7 @@ class SearchBugsForm
   attr_accessor :search_word
 
   def search
-    relation = Bug.distinct
+    relation = Bug.includes(image_attachment: :blob).distinct
 
     if search_word.present?
       search_words = search_word.split(/[[:blank:]]+/)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,14 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on


### PR DESCRIPTION
close #51 
## 概要

- bulletというGemをインストールする
- 虫一覧ページでbugモデルとactivestorage間で発生しているN+1問題を解消する

## 確認方法

虫一覧ページで発生していたN+1問題が解消されていること。
