### PR TITLE
余計なbeforeactionを修正

### DIFF
--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -2,7 +2,7 @@ class BugsController < ApplicationController
   include SearchImagesHelper
 
   before_action :set_bug, only: %i[edit update destroy]
-  skip_before_action :require_login, only: %i[index show]
+  skip_before_action :require_login, only: %i[index show image_search]
 
   def index
     @search_bugs_form = SearchBugsForm.new(search_params)

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,6 +1,8 @@
 class NewsController < ApplicationController
   include NewsHelper
 
+  skip_before_action :require_login
+
   def index
     @news_list = get_news
   end

--- a/app/helpers/search_images_helper.rb
+++ b/app/helpers/search_images_helper.rb
@@ -80,7 +80,7 @@ module SearchImagesHelper
   end
 
   def label_search(label_list)
-    relation = Bug.distinct
+    relation = Bug.includes(image_attachment: :blob).distinct
 
     result = []
 


### PR DESCRIPTION
## 概要

画像検索とニュース一覧ページにログイン必須のbeforeactionが適用されていたので外した